### PR TITLE
Fix install one-liner to pipe RAW file into BASH

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Follow these steps to install Shake&Tune on your printer:
 
   1. Install Shake&Tune by running over SSH on your printer:
      ```bash
-     cd /home/mks && wget -O - https://github.com/qidi-community/ShakeTune-For-Plus4/blob/main/install.sh | bash
+     cd /home/mks && wget -O - https://raw.githubusercontent.com/qidi-community/ShakeTune-For-Plus4/refs/heads/main/install.sh | bash
      ```
 
   1. Then, insert the following into your `printer.cfg` file BEFORE the `SAVE_CONFIG` section and restart Klipper:


### PR DESCRIPTION
The existing one-liner gives a BASH error because it is an HTML file that is pulled down.  This fix pulls down the actual script file to pipe to the bash command.